### PR TITLE
docker compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 # name of executable when built using command 'go build'
 elektron
+# test log directory name.
+elektron-test-run*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 # name of executable when built using command 'go build'
 elektron
 # test log directory name.
-elektron-test-run*
+Elektron-Test-Run*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# Copyright (C) 2018 spdfg
+#
+# This file is part of Elektron.
+#
+# Elektron is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Elektron is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Elektron.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get -y install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common && \
+    apt-get install -yq ssh git
+
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+	apt-get update && \
+	apt-get install -y python3.7
+
+# Installing performance co-pilot.
+RUN apt-get install -y pcp pcp-gui
+
+# The name of the elektron executable.
+ARG elektronexecutablename=elektron
+ENV ELEKTRON_EXECUTABLE_NAME=$elektronexecutablename
+
+# HOST:PORT of the mesos master.
+ARG elektronmesosmasterlocation=localhost:5050
+ENV ELEKTRON_MESOS_MASTER_LOCATION=$elektronmesosmasterlocation
+
+# Workload to be scheduled.
+ARG elektronworkload=workload_sample.json
+ENV ELEKTRON_WORKLOAD=$elektronworkload
+
+# Prefix of the log directory.
+ARG elektronlogdirprefix=Elektron-Test-Run
+ENV ELEKTRON_LOGDIR_PREFIX=$elektronlogdirprefix
+
+# Hostname/IP Address of the physical machine on which the docker containers are being run.
+# This is used to create the pcp config file.
+ARG hostip=""
+ENV HOST_IP=$hostip
+
+# Creating directory into which the current directory is going to be mounted.
+RUN mkdir /elektron
+ADD ./ /elektron
+WORKDIR /elektron
+RUN chmod 777 /elektron/entrypoint.sh
+
+ENTRYPOINT ["/elektron/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -55,13 +55,63 @@ If vendoring dependencies, then use the below commands after cloning _elektron_.
 
 An alternative is to clone _elektron_ using the command `git clone --recurse-submodules git@github.com:spdfg/elektron.git`.
 
-
-## Build and Run
+## Build
 Compile the source code using the `go build` tool as shown below.
 ```commandline
 go build -o elektron
 ```
 Use the `-h` option to get information about other command-line options.
+
+## Run
+Elektron can be run on bare-metal or using a docker-compose environment.
+### Bare-Metal
+Follow instructions [here](http://mesos.apache.org/documentation/latest/building/) to setup a Mesos cluster.
+In addition, the following software should be installed.
+
+| Software 				| Target Machines 			|
+|-----------------------|---------------------------|
+| [Performance Co-Pilot](http://pcp.io/) | Mesos master nodes + agent nodes |
+| [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/) | Mesos agent nodes |
+
+If power consumption needs to be monitored, install the perfevent PMDA by following the instructions [here](https://pcp.io/man/man1/pmdaperfevent.1.html).
+_Note: You might need to update the exposed event names for RAPL depending on the architecture_.
+For example, update _perfevent.conf_ with the following events if measuring both CPU and DRAM power.
+```
+rapl::RAPL_ENERGY_PKG node
+rapl::RAPL_ENERGY_DRAM node
+```
+
+**_Detail document on the bare-metal setup coming up soon!_**
+
+### Docker-Compose
+For local testing purposes, the docker-compose setup can be used. Follow instructions [here](https://docs.docker.com/compose/install/) to install docker-compose.
+
+The [entrypoint](./entrypoint.sh) script requires the IP address of the host machine to generate the [PCP config](./config).
+On a linux machine, the below command can be used to set it.
+```commandline
+export HOST_IP=$(curl ifconfig.me)
+```
+
+#### Environment Variables
+The following are the environment variables required to run _elektron_.
+
+| Environment Variable           | Description                   | Commandline Option (if any) |
+|--------------------------------|-------------------------------|-----------------------------|
+| ELEKTRON_EXECUTABLE_NAME       | Name of the elektron executable. Default = elektron |
+| ELEKTRON_MESOS_MASTER_LOCATION | HOST:PORT of the mesos master. Default = localhost:5050 | `-master` |
+| ELEKTRON_WORKLOAD              | Filename of workload json to be scheduled. Default = workload_sample.json | `-workload` |
+| ELEKLTRON_LOGDIR_PREFIX        | Prefix of the log directory generated. Default = Elektron-Test-Run | `-logPrefix` |
+
+Use the below command to run elektron using the docker-compose setup.
+```commandline
+	docker-compose run elektron
+```
+The Mesos master UI can be viewed from the host machine using _http://localhost:5050_.
+
+If any other commandline options need to be specified, for example using the [bin-packing](./schedulers/bin-packing.go) scheduling policy, use the below command.
+```commandline
+docker-compose run elektron -schedPolicy bin-packing
+```
 
 ### Workload
 Use the `-workload` option to specify the location of the workload json file. Below is an example workload.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       ELEKTRON_EXECUTABLE_NAME: elektron
       ELEKTRON_WORKLOAD: workload_sample.json
       ELEKTRON_MESOS_MASTER_LOCATION: 19.16.4.4:5050
-      ELEKTRON_LOGDIR_PREFIX: elektron-test-run
+      ELEKTRON_LOGDIR_PREFIX: Elektron-Test-Run
       HOST_IP: ${HOST_IP}
     networks:
       elektron-cluster:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,86 @@
+version: "2"
+
+services:
+  zk:
+    image: rdelvalle/zookeeper
+    restart: on-failure
+    ports:
+    - "2181:2181"
+    environment:
+      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
+      ZK_ID: 1
+    networks:
+      elektron-cluster:
+        ipv4_address: 19.16.4.3
+    logging:
+      driver: none
+        
+  mesos-master:
+    image: rdelvalle/mesos-master:1.5.1
+    restart: on-failure
+    ports:
+    - "5050:5050"
+    environment:
+      MESOS_ZK: zk://19.16.4.3:2181/mesos
+      MESOS_QUORUM: 1
+      MESOS_HOSTNAME: localhost
+      MESOS_CLUSTER: test-cluster
+      MESOS_REGISTRY: replicated_log
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      elektron-cluster:
+        ipv4_address: 19.16.4.4
+    logging:
+      driver: none
+    depends_on:
+    - zk
+
+  mesos-agent:
+    image: pkaushi1/mesos-agent-elektron:1.5.1
+    pid: host
+    restart: on-failure
+    ports:
+    - "5051:5051"
+    environment:
+      MESOS_MASTER: zk://19.16.4.3:2181/mesos
+      MESOS_CONTAINERIZERS: mesos,docker
+      MESOS_ISOLATION: cgroups/cpu
+      MESOS_PORT: 5051
+      MESOS_HOSTNAME: localhost
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_SYSTEMD_ENABLE_SUPPORT: 'false'
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      elektron-cluster:
+        ipv4_address: 19.16.4.5
+    logging:
+      driver: none
+    volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup
+    - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+    - mesos-master
+
+  elektron:
+    image: pkaushi1/elektron:v1
+    restart: on-failure
+    environment:
+      ELEKTRON_EXECUTABLE_NAME: elektron
+      ELEKTRON_WORKLOAD: workload_sample.json
+      ELEKTRON_MESOS_MASTER_LOCATION: 19.16.4.4:5050
+      ELEKTRON_LOGDIR_PREFIX: elektron-test-run
+      HOST_IP: ${HOST_IP}
+    networks:
+      elektron-cluster:
+        ipv4_address: 19.16.4.6
+    volumes:
+      - ./:/elektron
+    depends_on:
+    - mesos-agent
+
+networks:
+  elektron-cluster:
+    ipam:
+      config:
+      - subnet: 19.16.4.0/16
+        gateway: 19.16.4.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
     - zk
 
   mesos-agent:
-    image: pkaushi1/mesos-agent-elektron:1.5.1
+    image: spdf/mesos-agent-elektron:1.5.1
     pid: host
     restart: on-failure
     ports:
@@ -79,7 +79,7 @@ services:
     - mesos-master
 
   elektron:
-    image: pkaushi1/elektron:v1
+    image: spdf/elektron:v1
     restart: on-failure
     environment:
       ELEKTRON_EXECUTABLE_NAME: elektron

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,20 @@
+# Copyright (C) 2018 spdfg
+#
+# This file is part of Elektron.
+#
+# Elektron is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Elektron is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Elektron.  If not, see <http://www.gnu.org/licenses/>.
+#
 version: "2"
 
 services:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,21 @@
 #!/usr/bin/env bash
+# Copyright (C) 2018 spdfg
+#
+# This file is part of Elektron.
+#
+# Elektron is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Elektron is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Elektron.  If not, see <http://www.gnu.org/licenses/>.
+#
 
 # Accessing host machine's ip address.
 hostip=$HOST_IP

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Accessing host machine's ip address.
+hostip=$HOST_IP
+
+# setting up metrics to be monitored.
+# creating PCP config with the cpu and memory usage metrics to be monitored.
+cat >config <<EOL
+${hostip}:kernel.all.cpu.user
+${hostip}:kernel.all.cpu.sys
+${hostip}:kernel.all.cpu.idle
+${hostip}:mem.util.free
+${hostip}:mem.util.used
+EOL
+
+./$ELEKTRON_EXECUTABLE_NAME -m $ELEKTRON_MESOS_MASTER_LOCATION -w $ELEKTRON_WORKLOAD -p $ELEKTRON_LOGDIR_PREFIX $@


### PR DESCRIPTION
1. Added Dockerfile to help containerize Elektron.
2. Added docker-compose yaml file to setup mesos cluster for elektron.

The docker image tagged [`rdelvalle/mesos-master:1.5.1`](https://github.com/ridv/aurora-docker/blob/master/mesos/master/Dockerfile) was used as the mesos master.
As the mesos agent for Elektron requires additional software (docker, PCP) [`pkaushi1/mesos-agent-elektron:1.5.1`](https://github.com/spdfg/elektron-mesos-agent-dockerfile) was built using [`rdelvalle/mesos:1.5.1`](https://github.com/ridv/aurora-docker/blob/master/mesos/Dockerfile) as the base image.

Use the below commands to run elektron.
```commandline
docker-compose run elektron
```